### PR TITLE
add : stateDB

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 var (
 	homePath, _ = os.UserHomeDir()
 	dbPath      = homePath + "/.compact-chain/db"
+	stateDbPath = homePath + "/.compact-chain/statedb"
 )
 
 func demoBlockchain() {
@@ -52,6 +53,7 @@ func demoBlockchain() {
 		ConsensusDifficulty: 16,
 		ConsensusName:       "pow",
 		DBDir:               dbPath,
+		StateDBDir:          stateDbPath,
 	}
 
 	chain := core.NewBlockchain(config)

--- a/config/config.go
+++ b/config/config.go
@@ -5,4 +5,5 @@ type Config struct {
 	ConsensusDifficulty int
 	ConsensusName       string
 	DBDir               string
+	StateDBDir          string
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -18,6 +18,7 @@ type Blockchain struct {
 	Mutex     *sync.RWMutex
 	LastHash  *util.Hash
 	Db        *dbstore.DB
+	StateDB   *dbstore.DB
 }
 
 // defaultConsensusDifficulty is the default difficulty for the proof of work consensus.
@@ -26,6 +27,11 @@ var defaultConsensusDifficulty = 10
 // NewBlockchain creates a new blockchain with the given config.
 func NewBlockchain(c *config.Config) *Blockchain {
 	db, err := dbstore.NewDB(c.DBDir)
+	if err != nil {
+		panic(err)
+	}
+
+	stateDB, err := dbstore.NewDB(c.StateDBDir)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +79,7 @@ func NewBlockchain(c *config.Config) *Blockchain {
 		panic("Invalid consensus algorithm")
 	}
 
-	bc := &Blockchain{LastBlock: lastBlock, Consensus: consensus, Mutex: new(sync.RWMutex), Db: db, LastHash: lastBlock.Hash}
+	bc := &Blockchain{LastBlock: lastBlock, Consensus: consensus, Mutex: new(sync.RWMutex), Db: db, LastHash: lastBlock.Hash, StateDB: stateDB}
 
 	return bc
 }


### PR DESCRIPTION
In this PR, we add levelDB based state in the blockchain struct. 

> NOTE : merkle-patricia-tree based on leveldb is a better option and R&D is in progress